### PR TITLE
Update curl command to work in apache script

### DIFF
--- a/certera/adguard.sh
+++ b/certera/adguard.sh
@@ -26,9 +26,9 @@ time_stamp=/opt/certera/timestamp.txt
 
 sudo mkdir $local_certs/temp
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --out $local_certs/temp/fullchain.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --output $local_certs/temp/fullchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --out $local_certs/temp/privkey.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --output $local_certs/temp/privkey.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/certera/apache2.sh
+++ b/certera/apache2.sh
@@ -26,9 +26,9 @@ time_stamp=/etc/apache2/certera.txt
 
 sudo mkdir $local_certs/temp
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --out $local_certs/temp/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --output $local_certs/temp/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --out $local_certs/temp/key.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --output $local_certs/temp/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/certera/dell-idrac.sh
+++ b/certera/dell-idrac.sh
@@ -67,9 +67,9 @@ for i in "${!idrac_list[@]}"; do
 	if [[ $? != 0 ]]; then continue; fi
 
 	# Fetch certera certs; end this iteration of the loop if curl doesn't work properly
-	http_statuscode=$(sudo curl https://$server/api/certificate/${idrac_list[$i]} -H "apiKey: ${cert_apikey[$i]}" --out $temp_certs/certchain.pem --write-out "%{http_code}" -G)
+	http_statuscode=$(sudo curl https://$server/api/certificate/${idrac_list[$i]} -H "apiKey: ${cert_apikey[$i]}" --output $temp_certs/certchain.pem --write-out "%{http_code}" -G)
 	if test $http_statuscode -ne 200; then continue; fi
-	http_statuscode=$(sudo curl https://$server/api/key/${idrac_list[$i]} -H "apiKey: ${key_apikey[$i]}" --out $temp_certs/key.pem --write-out "%{http_code}")
+	http_statuscode=$(sudo curl https://$server/api/key/${idrac_list[$i]} -H "apiKey: ${key_apikey[$i]}" --output $temp_certs/key.pem --write-out "%{http_code}")
 	if test $http_statuscode -ne 200; then continue; fi
 
 	# Split the pem chain to then combine the multiple files into a format drac will take

--- a/certera/edge-switch.sh
+++ b/certera/edge-switch.sh
@@ -82,9 +82,9 @@ for i in "${!edgesw_list[@]}"; do
 	if [[ $? != 0 ]]; then continue; fi
 
 	# Fetch certera certs; end this iteration of the loop if curl doesn't work properly
-	http_statuscode=$(sudo curl -k https://$certserver/api/certificate/${edgesw_list[$i]} -H "apiKey: ${cert_apikey[$i]}" --out $temp_certs/certchain.pem --write-out "%{http_code}" -G)
+	http_statuscode=$(sudo curl -k https://$certserver/api/certificate/${edgesw_list[$i]} -H "apiKey: ${cert_apikey[$i]}" --output $temp_certs/certchain.pem --write-out "%{http_code}" -G)
 	if test $http_statuscode -ne 200; then continue; fi
-	http_statuscode=$(sudo curl -k https://$certserver/api/key/${edgesw_list[$i]} -H "apiKey: ${key_apikey[$i]}" --out $temp_certs/key.pem --write-out "%{http_code}")
+	http_statuscode=$(sudo curl -k https://$certserver/api/key/${edgesw_list[$i]} -H "apiKey: ${key_apikey[$i]}" --output $temp_certs/key.pem --write-out "%{http_code}")
 	if test $http_statuscode -ne 200; then continue; fi
 
 	# Fetch cert chain from the switch by connecting with SSL (don't fail out if cert isn't collected, instead assume SSL isn't configured yet and continue)

--- a/certera/full-chain-pem.sh
+++ b/certera/full-chain-pem.sh
@@ -30,9 +30,9 @@ time_stamp=/opt/certera/timestamp.txt
 
 sudo mkdir $local_certs/temp
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --out $local_certs/temp/fullchain.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --output $local_certs/temp/fullchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --out $local_certs/temp/privkey.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --output $local_certs/temp/privkey.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/certera/media-server-plex.sh
+++ b/certera/media-server-plex.sh
@@ -35,9 +35,9 @@ script_path="`( cd \"$MY_PATH\" && pwd )`"
 
 sudo mkdir $temp_certs
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --out $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --out $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # Update plex

--- a/certera/unifi-controller.sh
+++ b/certera/unifi-controller.sh
@@ -36,9 +36,9 @@ time_stamp=/home/greg/certera.txt
 ## Script
 sudo mkdir $temp_certs
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --out $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/certificate/$cert_name -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --out $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(sudo curl https://$server/api/key/$cert_name -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/cw-adguard.sh
+++ b/cw-adguard.sh
@@ -45,9 +45,9 @@ rm -rf $temp_certs
 mkdir -p $temp_certs
 mkdir -p $local_certs
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(curl -L https://$server/$api_cert_path -H "apiKey: $cert_apikey" --out $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_cert_path -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(curl -L https://$server/$api_key_path -H "apiKey: $key_apikey" --out $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_key_path -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/cw-apache2.sh
+++ b/cw-apache2.sh
@@ -45,9 +45,9 @@ set -e
 mkdir -p "$temp_certs"
 
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(curl -L https://$server/$api_cert_path -H "apiKey: $cert_apikey" --out $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_cert_path -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(curl -L https://$server/$api_key_path -H "apiKey: $key_apikey" --out $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_key_path -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # if different

--- a/cw-media-server-plex.sh
+++ b/cw-media-server-plex.sh
@@ -53,9 +53,9 @@ chown root:root $nginx_certs
 chmod 0755 $nginx_certs
 
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(-L curl https://$server/$api_cert_path -H "apiKey: $cert_apikey" --out $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(-L curl https://$server/$api_cert_path -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(-L curl https://$server/$api_key_path -H "apiKey: $key_apikey" --out $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(-L curl https://$server/$api_key_path -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # Update plex

--- a/cw-media-server-plex.sh
+++ b/cw-media-server-plex.sh
@@ -53,9 +53,9 @@ chown root:root $nginx_certs
 chmod 0755 $nginx_certs
 
 # Fetch certs, if curl returns anything other than 200 success, abort
-http_statuscode=$(-L curl https://$server/$api_cert_path -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_cert_path -H "apiKey: $cert_apikey" --output $temp_certs/certchain.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
-http_statuscode=$(-L curl https://$server/$api_key_path -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
+http_statuscode=$(curl -L https://$server/$api_key_path -H "apiKey: $key_apikey" --output $temp_certs/key.pem --write-out "%{http_code}")
 if test $http_statuscode -ne 200; then exit "$http_statuscode"; fi
 
 # Update plex


### PR DESCRIPTION
using --out yields "curl: option --out: is ambiguous" - the actual command line flag is named `--output` (or `-o`).

source: [curl documentation](https://curl.se/docs/manpage.html#output)

`cw-media-server-plex` also had the syntax completely off, stating `$(-L curl http...` - where the -L should be after the actual command.