### PR TITLE
Jellyfin media server certificate script

### DIFF
--- a/cw-media-server-jellyfin
+++ b/cw-media-server-jellyfin
@@ -1,0 +1,78 @@
+#!/bin/sh
+# This script should be securely placed with limited access
+# (e.g. owned by root with permissions of 700) to avoid
+# compromising the API Keys
+
+# For example, you can place the script in /root/certwarden.
+
+# Recommended cron -- run at boot (in case system was powered off
+# during a renewal, and run weekly)
+# Pick any time you like. This time was arbitrarily selected.
+
+# apt install cron -y
+# crontab -e
+# @reboot sleep 15 && /script/path/here
+# 5 4 * * 2 /script/path/here
+
+# NOTE: If Cert Warden server is running on a VM, add sleep 300-600 to wait 5-10 minutes for
+# the VM to come up
+
+# Variables (Replace placeholders with your actual values)
+cert_apikey="<your_cert_api_key>"
+# NOTE! Use API key for the private key as a "Certificate password" in Jellyfin UI (Dashboard -> Networking -> HTTPS Settings)
+key_apikey="<your_key_api_key>"                             
+server="<your_cert_warden_server>:<port>"
+cert_name="<your_certificate_name>"
+
+# Jellyfin Server certificate and key paths (adjust as necessary)
+jellyfin_cert="/var/lib/jellyfin/certs/jellyfin-cert.pfx"   # NOTE! create "certs" folder in /var/lib/jellyfin (or specify your own)
+cert_owner="jellyfin:jellyfin"                              # NOTE! update user:group if you run jellyfin using different user
+cert_permissions="640"
+temp_certs="/tmp/tempcerts"
+time_stamp_dir="/root/certwarden"
+time_stamp="/root/certwarden/timestamp.txt"
+
+# Stop the script on any error
+set -e
+
+# Create temp directory for certs
+mkdir -p $temp_certs
+mkdir -p $time_stamp_dir
+
+# Special API key format required by Cert Warden for combined key & cert with chain download
+combined_apikey="$cert_apikey.$key_apikey"
+
+# Fetch PKCS#12 certificate with key from Cert Warden
+http_statuscode=$(wget "https://$server//certwarden/api/v1/download/pfx/$cert_name" --header="X-API-Key: $combined_apikey" -O "$temp_certs/jellyfin-cert.pfx" --server-response 2>&1 | tee /dev/tty | awk '/^  HTTP/{print $2}')
+if [ "$http_statuscode" -ne 200 ]; then
+    echo "Error: Failed to fetch the PKCS#12 certificate. HTTP Status Code: $http_statuscode"
+    exit 1
+fi
+
+# Verify that the files are not empty
+if [ ! -s "$temp_certs/jellyfin-cert.pfx" ]; then
+    echo "Error: One or more downloaded files are empty"
+    exit 1
+fi
+
+# Compare the new certificate with the existing one
+if ! diff -s "$jellyfin_cert" "$temp_certs/jellyfin-cert.pfx"; then
+    # If different, update the Jellyfin Server certificate and key
+    cp -f "$temp_certs/jellyfin-cert.pfx" "$jellyfin_cert"
+    
+    # Set ownership and permissions
+    chown $cert_owner "$jellyfin_cert"
+    chmod $cert_permissions "$jellyfin_cert"
+
+    # Reload the Jellyfin Server service (without restarting)
+    systemctl restart jellyfin
+    echo "Certificate and key updated, and Jellyfin service is reloaded."
+else
+    echo "Certificate is already up to date."
+fi
+
+# Clean up temporary files
+rm -rf $temp_certs
+
+# Log the last run time
+echo "Last Run: $(date)" > $time_stamp


### PR DESCRIPTION
Hi! I hope this can be useful for someone. I've adopted your scripts to support Jellyfin.
This client script requests and manages certificates for Jellyfin media server deployed as VM or LXC.
The script requests PKCS#12 cert, required for Jellyfin.

Comments in script provide additional guidance on how this script should be used.
Example:
```
# NOTE! Use API key for the private key as a "Certificate password" in Jellyfin UI (Dashboard -> Networking -> HTTPS Settings)
key_apikey="<your_key_api_key>"                             

jellyfin_cert="/var/lib/jellyfin/certs/jellyfin-cert.pfx"   # NOTE! create "certs" folder in /var/lib/jellyfin (or specify your own)
cert_owner="jellyfin:jellyfin"                              # NOTE! update user:group if you run jellyfin using different user
```

