### PR TITLE
Set umask before file creation to prevent readings in transit

### DIFF
--- a/cw-adguard.sh
+++ b/cw-adguard.sh
@@ -41,6 +41,9 @@ temp_certs=/tmp/tempcerts
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 rm -rf $temp_certs
 mkdir -p $temp_certs
 mkdir -p $local_certs

--- a/cw-apache2.sh
+++ b/cw-apache2.sh
@@ -41,6 +41,9 @@ temp_certs=/tmp/tempcerts
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 # Make folder if doesn't exist
 mkdir -p "$temp_certs"
 

--- a/cw-docker.sh
+++ b/cw-docker.sh
@@ -33,6 +33,9 @@ fi
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 mkdir -p $temp_certs
 mkdir -p $local_certs
 chown root:root $local_certs

--- a/cw-gitea.sh
+++ b/cw-gitea.sh
@@ -48,6 +48,9 @@ time_stamp="$time_stamp_dir/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs and timestamp directory if they don't exist
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-grafana.sh
+++ b/cw-grafana.sh
@@ -47,6 +47,9 @@ time_stamp="$time_stamp_dir/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs and timestamp directory if they don't exist
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-iobroker.sh
+++ b/cw-iobroker.sh
@@ -47,6 +47,9 @@ time_stamp="$time_stamp_dir/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs and timestamp directory if they don't exist
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-media-server-jellyfin
+++ b/cw-media-server-jellyfin
@@ -35,6 +35,9 @@ time_stamp="/root/certwarden/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-media-server-plex.sh
+++ b/cw-media-server-plex.sh
@@ -43,6 +43,9 @@ temp_certs=/tmp/tempcerts
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 rm -rf $temp_certs
 mkdir -p $temp_certs
 mkdir -p $plex_certs

--- a/cw-nginx.sh
+++ b/cw-nginx.sh
@@ -38,6 +38,9 @@ time_stamp="$time_stamp_dir/timestamp.txt"
 # Exit on any error, treat unset variables as errors, and propagate errors in pipelines
 set -euo pipefail
 
+# Set umask
+umask 077
+
 # Enable debugging (optional, uncomment for detailed logs)
 # set -x
 

--- a/cw-pfsense.sh
+++ b/cw-pfsense.sh
@@ -50,6 +50,9 @@ pfsense_cert_name="certwarden pfsense.example.com"
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 # Make folders if don't exist
 mkdir -p "$temp_certs"
 

--- a/cw-proxmox_backup_server.sh
+++ b/cw-proxmox_backup_server.sh
@@ -35,6 +35,9 @@ time_stamp="/root/certwarden/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-proxmox_pve.sh
+++ b/cw-proxmox_pve.sh
@@ -35,6 +35,9 @@ time_stamp="$time_stamp_dir/timestamp.txt"
 # Stop the script on any error
 set -e
 
+# Set umask
+umask 077
+
 # Create temp directory for certs and timestamp directory if they don't exist
 mkdir -p $temp_certs
 mkdir -p $time_stamp_dir

--- a/cw-unifi-controller.sh
+++ b/cw-unifi-controller.sh
@@ -43,6 +43,9 @@ time_stamp=/var/lib/unifi/cert_timestamp.txt
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 rm -rf $temp_certs
 mkdir -p $temp_certs
 mkdir -p $app_certs

--- a/cw-unifi-udm.sh
+++ b/cw-unifi-udm.sh
@@ -38,6 +38,9 @@ temp_certs=/tmp/tempcerts
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 rm -rf $temp_certs
 mkdir -p $temp_certs
 mkdir -p $local_certs

--- a/cw-xcp-ng.sh
+++ b/cw-xcp-ng.sh
@@ -42,6 +42,9 @@ time_stamp=/root/certwarden/timestamp.txt
 # stop / fail on any error
 set -e
 
+# Set umask
+umask 077
+
 mkdir -p $temp_certs
 # Fetch Cert Warden
 http_statuscode=$(wget https://$server/$api_cert_path --header="apiKey: $cert_apikey" -O $temp_certs/cert.pem --server-response 2>&1 | tee /dev/tty | awk '/^  HTTP/{print $2}')


### PR DESCRIPTION
This makes the default created files not readable by group or other.
Otherwise the files could be read by someone while they are being processed.
Is only after the proper owner is set that we change the permissions to what they should be.

It cost nothing and adds security to the process.