### PR TITLE
cw-adguard.sh remove bash dependency

### DIFF
--- a/cw-adguard.sh
+++ b/cw-adguard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Script updates AdGuard certchain and key. It also restarts
 # the AdGuard service.


### PR DESCRIPTION
This script doesn't use any bash only syntax.
Changing shebang to just use sh so it runs fine on Alpine.

selfh.st alpine script uses `adguardhome` for the service instead of `AdGuardHome`, but that's is left as an exercise for the user

I could also try to remove the `curl`  dependency and just use `wget` as that one is usually more command than the former.